### PR TITLE
feat: add exchange filtering to queue all stocks API

### DIFF
--- a/services/api/serializers.py
+++ b/services/api/serializers.py
@@ -216,13 +216,20 @@ class QueueAllStocksRequestSerializer(serializers.Serializer):
     Serializer for validating queue-all-stocks requests.
     
     Used to validate the POST request body when queuing all
-    stocks for ingestion via bulk operation.
+    stocks for ingestion via bulk operation. Supports optional
+    exchange filtering to queue only stocks from a specific exchange.
     """
     requested_by = serializers.CharField(
         max_length=255,
         required=False,
         allow_blank=True,
         help_text="Identifier for the requesting entity"
+    )
+    exchange = serializers.CharField(
+        max_length=50,
+        required=False,
+        allow_blank=True,
+        help_text="Exchange name to filter stocks by (e.g., 'NASDAQ', 'NYSE')"
     )
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Stocks can now be filtered by exchange when queuing for bulk ingestion. Users can specify an exchange name (e.g., 'NASDAQ', 'NYSE'), which is automatically normalized for consistency.

**Tests**
* Added comprehensive test coverage for exchange filtering functionality, validating normalization, non-existent exchanges, and various edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->