### PR TITLE
fix: add run_id to ingestion run filter

### DIFF
--- a/services/api/filters.py
+++ b/services/api/filters.py
@@ -48,6 +48,7 @@ class StockIngestionRunFilter(filters.FilterSet):
     FilterSet for StockIngestionRun model.
     
     Provides comprehensive filtering for ingestion run list views:
+    - run_id: Filter by ingestion run UUID (exact match)
     - ticker: Filter by stock ticker (exact or contains)
     - state: Filter by ingestion state
     - requested_by: Filter by requester identifier
@@ -58,6 +59,7 @@ class StockIngestionRunFilter(filters.FilterSet):
     - bulk_queue_run: Filter by BulkQueueRun UUID
     
     Example usage:
+        ?run_id=550e8400-e29b-41d4-a716-446655440000  # Specific run by UUID
         ?ticker=AAPL                           # Runs for AAPL
         ?ticker__icontains=app                 # Runs for tickers containing 'app'
         ?state=FAILED                          # Failed runs only
@@ -70,6 +72,7 @@ class StockIngestionRunFilter(filters.FilterSet):
         ?state=FAILED&created_after=2025-01-01 # Multiple filters combined
         ?bulk_queue_run=<uuid>&state=FAILED    # Failed runs from a bulk operation
     """
+    run_id = filters.UUIDFilter(field_name='id', lookup_expr='exact')
     ticker = filters.CharFilter(field_name='stock__ticker', lookup_expr='iexact')
     ticker__icontains = filters.CharFilter(field_name='stock__ticker', lookup_expr='icontains')
     state = filters.ChoiceFilter(field_name='state', choices=IngestionState.choices)

--- a/services/api/views.py
+++ b/services/api/views.py
@@ -354,7 +354,7 @@ class RunListView(ListAPIView):
     GET /runs
     
     Returns a paginated list of all ingestion runs with cursor-based pagination.
-    Supports filtering by ticker, state, requested_by, date ranges, and terminal/in-progress status.
+    Supports filtering by run_id, ticker, state, requested_by, date ranges, and terminal/in-progress status.
     """
     permission_classes = [AllowAny]
     serializer_class = StockIngestionRunSerializer
@@ -371,7 +371,7 @@ class TickerRunsListView(ListAPIView):
     GET /runs/ticker/<ticker>
     
     Returns a paginated list of runs for the specified ticker.
-    Supports additional filtering by state, requested_by, date ranges, and terminal/in-progress status.
+    Supports additional filtering by run_id, state, requested_by, date ranges, and terminal/in-progress status.
     """
     permission_classes = [AllowAny]
     serializer_class = StockIngestionRunSerializer


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added run_id filter field to enable querying stock ingestion runs by exact UUID match.

* **Documentation**
  * Updated API documentation for RunListView and TickerRunsListView to reflect the new run_id filter option.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->